### PR TITLE
add isSupported() method

### DIFF
--- a/getusermedia.bundle.js
+++ b/getusermedia.bundle.js
@@ -1,11 +1,14 @@
-(function(e){if("function"==typeof bootstrap)bootstrap("getusermedia",e);else if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else if("undefined"!=typeof ses){if(!ses.ok())return;ses.makeGetUserMedia=e}else"undefined"!=typeof window?window.getUserMedia=e():global.getUserMedia=e()})(function(){var define,ses,bootstrap,module,exports;
-return (function(e,t,n){function i(n,s){if(!t[n]){if(!e[n]){var o=typeof require=="function"&&require;if(!s&&o)return o(n,!0);if(r)return r(n,!0);throw new Error("Cannot find module '"+n+"'")}var u=t[n]={exports:{}};e[n][0].call(u.exports,function(t){var r=e[n][1][t];return i(r?r:t)},u,u.exports)}return t[n].exports}var r=typeof require=="function"&&require;for(var s=0;s<n.length;s++)i(n[s]);return i})({1:[function(require,module,exports){
+!function(e){"object"==typeof exports?module.exports=e():"function"==typeof define&&define.amd?define(e):"undefined"!=typeof window?window.getUserMedia=e():"undefined"!=typeof global?global.getUserMedia=e():"undefined"!=typeof self&&(self.getUserMedia=e())}(function(){var define,module,exports;
+return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 // getUserMedia helper by @HenrikJoreteg
 var func = (navigator.getUserMedia ||
             navigator.webkitGetUserMedia ||
             navigator.mozGetUserMedia ||
             navigator.msGetUserMedia);
-
+            
+function isSupported() {
+    return !!func;
+}
 
 module.exports = function (constraints, cb) {
     var options;
@@ -22,7 +25,7 @@ module.exports = function (constraints, cb) {
     }
 
     // treat lack of browser support like an error
-    if (!func) {
+    if (!isSupported()) {
         // throw proper error per spec
         error = new Error('NavigatorUserMediaError');
         error.name = 'NOT_SUPPORTED_ERROR';
@@ -63,6 +66,9 @@ module.exports = function (constraints, cb) {
     });
 };
 
-},{}]},{},[1])(1)
+module.exports.isSupported = isSupported;
+
+},{}]},{},[1])
+(1)
 });
 ;

--- a/getusermedia.js
+++ b/getusermedia.js
@@ -3,7 +3,10 @@ var func = (navigator.getUserMedia ||
             navigator.webkitGetUserMedia ||
             navigator.mozGetUserMedia ||
             navigator.msGetUserMedia);
-
+            
+function isSupported() {
+    return !!func;
+}
 
 module.exports = function (constraints, cb) {
     var options;
@@ -20,7 +23,7 @@ module.exports = function (constraints, cb) {
     }
 
     // treat lack of browser support like an error
-    if (!func) {
+    if (!isSupported()) {
         // throw proper error per spec
         error = new Error('NavigatorUserMediaError');
         error.name = 'NOT_SUPPORTED_ERROR';
@@ -60,3 +63,5 @@ module.exports = function (constraints, cb) {
         cb(error);
     });
 };
+
+module.exports.isSupported = isSupported;


### PR DESCRIPTION
Thanks for making getUserMedia available, it is convenient to pick up and use.

I ran into a situation where I wanted to detect if getUserMedia was supported before other initialization that happens before actually calling getUserMedia.  So in this pull request I add an exported method isSupported() to allow this check.