### PR TITLE
New errors

### DIFF
--- a/getusermedia.bundle.js
+++ b/getusermedia.bundle.js
@@ -31,6 +31,19 @@ module.exports = function (constraints, cb) {
         }, 0);
     }
 
+    // make requesting media from non-http sources trigger an error
+    // current browsers silently drop the request instead
+    var protocol = window.location.protocol;
+    if (protocol !== 'http:' && protocol !== 'https:') {
+        error = new Error('MediaStreamError');
+        error.name = 'NotSupportedError';
+
+        // keep all callbacks async
+        return window.setTimeout(function () {
+            cb(error);
+        }, 0);
+    }
+
     // normalize error handling when no media types are requested
     if (!constraints.audio && !constraints.video) {
         error = new Error('MediaStreamError');

--- a/index-browser.js
+++ b/index-browser.js
@@ -30,6 +30,19 @@ module.exports = function (constraints, cb) {
         }, 0);
     }
 
+    // make requesting media from non-http sources trigger an error
+    // current browsers silently drop the request instead
+    var protocol = window.location.protocol;
+    if (protocol !== 'http:' && protocol !== 'https:') {
+        error = new Error('MediaStreamError');
+        error.name = 'NotSupportedError';
+
+        // keep all callbacks async
+        return window.setTimeout(function () {
+            cb(error);
+        }, 0);
+    }
+
     // normalize error handling when no media types are requested
     if (!constraints.audio && !constraints.video) {
         error = new Error('MediaStreamError');


### PR DESCRIPTION
Normalize some more browser inconsistencies with handling error cases:
- If no media types requested, trigger `NoMediaRequestedError`
- If used from non `http`/`https` source, trigger `NotSupportedError`

To consider for review, based on the latest spec: This custom `NoMediaRequestedError` is actually spec'd as `NotSupportedError`, which would mean we need a different custom error for when GUM isn't available at all.
