### PR TITLE
actually test things with travis multirunner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,5 @@ before_script:
 after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
 
-notifications:
-  email:
-  - henrik@andyet.net
+script:
+  - npm test-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ after_failure:
   - for file in *.log; do echo $file; echo "======================"; cat $file; done || true
 
 script:
-  - npm test-travis
+  - npm run test-travis

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "testling": {
     "files": "test/test.js"
   },
+  "scripts": {
+    "test-travis": "test/run-tests"
+  },
   "devDependencies": {
     "browserify": "^10.2.1",
     "precommit-hook": "1.x",

--- a/test/run-tests
+++ b/test/run-tests
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Run testling with a default set of parameters
+#
+BINDIR=./browsers/bin
+export BROWSER=${BROWSER-chrome}
+export BVER=${BVER-stable}
+BROWSERBIN=$BINDIR/$BROWSER-$BVER
+if [ ! -x $BROWSERBIN ]; then
+  echo "Installing browser"
+  ./node_modules/travis-multirunner/setup.sh
+fi
+echo "Starting browser"
+PATH=$PATH:./node_modules/.bin
+
+testling -x start-${BROWSER}


### PR DESCRIPTION
can't use npm test since that will run with precommit-hook

We don't do jshint in travis but that's ok since precommit-hook will catch that.