### PR TITLE
bump adapter to 0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "webrtc-adapter-test": "^0.1.9"
+    "webrtc-adapter-test": "^0.2.3"
   },
   "testling": {
     "files": "test/test.js"


### PR DESCRIPTION
should solve the double-include issue hopefully