### PR TITLE
Support Electron

### DIFF
--- a/index-node.js
+++ b/index-node.js
@@ -1,6 +1,11 @@
 // Once there is an equivalent of getUserMedia for node.js,
 // we'll update this to use it.
 module.exports = function (constraints, cb) {
+    if (typeof navigator !== 'undefined') {
+      // Support Electron renderer processes
+      return require('./index-browser')(constraints, cb);
+    }
+
     var haveOpts = arguments.length === 2;
 
     // make constraints optional


### PR DESCRIPTION
Electron will run the node version of this file, since it doesn't look
at the "browser" field in `package.json`. But it also has
`navigator.getUserMedia` available, so run the browser code in this
situation.